### PR TITLE
Restore RN window as the key window after the Unity initializes

### DIFF
--- a/ios/UnityUtils.mm
+++ b/ios/UnityUtils.mm
@@ -142,9 +142,7 @@ static BOOL _isUnityReady = NO;
 
     dispatch_async(dispatch_get_main_queue(), ^{
         UIApplication* application = [UIApplication sharedApplication];
-
-        // Always keep RN window in top
-        application.keyWindow.windowLevel = UIWindowLevelNormal + 1;
+        UIWindow* prevKeyWindow = application.keyWindow;
 
         InitUnity();
 
@@ -153,6 +151,11 @@ static BOOL _isUnityReady = NO;
         [controller applicationDidBecomeActive:application];
 
         [UnityUtils listenAppState];
+
+        // Always keep RN window in top
+        controller.window.windowLevel = prevKeyWindow.windowLevel - 1;
+        // Make RN window the key window again
+        [prevKeyWindow makeKeyWindow];
     });
 }
 


### PR DESCRIPTION
Changing the createPlayer function to more minimally affect the React Native window. Restoring it as the key window after Unity initialization, and lowering the Unity window level rather than raising the React Native window.