### PR TITLE
unload unity on unmount

### DIFF
--- a/android/src/main/java/no/asmadsen/unity/view/UnityNativeModule.java
+++ b/android/src/main/java/no/asmadsen/unity/view/UnityNativeModule.java
@@ -36,6 +36,16 @@ public class UnityNativeModule extends ReactContextBaseJavaModule implements Uni
     }
 
     @ReactMethod
+    public void unloadPlayer(final Promise promise) {
+        UnityUtils.unloadPlayer(getCurrentActivity(), new UnityUtils.CreateCallback() {
+            @Override
+            public void onReady() {
+                promise.resolve(true);
+            }
+        });
+    }
+    
+    @ReactMethod
     public void postMessage(String gameObject, String methodName, String message) {
         UnityUtils.postMessage(gameObject, methodName, message);
     }

--- a/android/src/main/java/no/asmadsen/unity/view/UnityUtils.java
+++ b/android/src/main/java/no/asmadsen/unity/view/UnityUtils.java
@@ -35,6 +35,7 @@ public class UnityUtils {
 
     public static void createPlayer(final Activity activity, final CreateCallback callback) {
         if (unityPlayer != null) {
+            _isUnityReady = true;
             callback.onReady();
             return;
         }
@@ -68,6 +69,21 @@ public class UnityUtils {
                     activity.getWindow().clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
                 }
                 _isUnityReady = true;
+                callback.onReady();
+            }
+        });
+    }
+
+    public static void unloadPlayer(final Activity activity, final CreateCallback callback) {
+        if (unityPlayer == null) {
+            callback.onReady();
+            return;
+        }
+        activity.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                unityPlayer.unload();
+                _isUnityReady = false;
                 callback.onReady();
             }
         });

--- a/src/UnityModule.ts
+++ b/src/UnityModule.ts
@@ -21,6 +21,11 @@ export interface UnityModule {
     createUnity (): Promise<boolean>;
 
     /**
+     * Manual destroy the Unity. This function should be call on your component unmount effect.
+     */
+    unloadPlayer(): Promise<boolean>;
+
+    /**
      * Send Message to UnityMessageManager.
      * @param message The message will post.
      */
@@ -110,6 +115,10 @@ class UnityModuleImpl implements UnityModule {
 
     public async isReady () {
         return UnityNativeModule.isReady()
+    }
+
+    public async unloadPlayer() {
+        return UnityNativeModule.unloadPlayer()
     }
 
     public async createUnity () {

--- a/src/UnityView.tsx
+++ b/src/UnityView.tsx
@@ -17,7 +17,9 @@ export interface UnityViewProps extends ViewProps {
      */
     onUnityMessage?: (handler: MessageHandler) => void;
 
-    children?: React.ReactNode
+    children?: React.ReactNode;
+
+    unloadOnUnmount?: boolean;
 }
 
 let NativeUnityView
@@ -43,7 +45,11 @@ class UnityView extends Component<UnityViewProps> {
     }
 
     componentWillUnmount(): void {
-        UnityModule.removeMessageListener(this.state.handle)
+        const { unloadOnUnmount } = this.props;
+        UnityModule.removeMessageListener(this.state.handle);
+        if (unloadOnUnmount) {
+          UnityModule.unloadPlayer();
+        }
     }
 
     render() {


### PR DESCRIPTION
Adds optional boolean prop `unloadOnUnmount` to `UnityView` which unloads all unity scenes but not game preparation. this is an optimization for the next run of your game which will be faster. And releases all scenes' memory.

Also, it expose `unloadPlayer` so you can manually decide when to unload all scenes.

Notes:
- iOS solution is pending, but I'm drafting this PR so any one can use it and recommend any solution.
- Update usage docs are pending