### PR TITLE
Makes RN window key window to handle events

### DIFF
--- a/ios/UnityUtils.mm
+++ b/ios/UnityUtils.mm
@@ -147,11 +147,14 @@ static BOOL _isUnityReady = NO;
         application.keyWindow.windowLevel = UIWindowLevelNormal + 1;
 
         InitUnity();
-
+        
         UnityAppController *controller = GetAppController();
         [controller application:application didFinishLaunchingWithOptions:nil];
         [controller applicationDidBecomeActive:application];
-
+        
+        // Makes RN window key window to handle events
+        [application.windows[1] makeKeyWindow];
+        
         [UnityUtils listenAppState];
     });
 }


### PR DESCRIPTION
Platform: iOS

With this commit React Native UI application window is set as key window after Unity initialization.

This solves the following issues:

- After Unity is initialized, alerts not showing up because of "window not in hierarchy" error. The alerts are meant to be handled in RN window, but since Unity becomes the key window in the hierarchy, the error happens.

![image_2020_08_14T10_35_31_187Z](https://user-images.githubusercontent.com/56125447/90241523-85532480-de2b-11ea-864d-726bf96165bd.png)

- Events like focusing keyboard which are supposed to be handled in RN are instead sent to Unity as key window which creates bugs